### PR TITLE
Correct the LayerNorm in SASRec

### DIFF
--- a/Result_Norm.md
+++ b/Result_Norm.md
@@ -1,0 +1,31 @@
+# Results on Layer Norm in SASRec
+
+## Experimental Settings
+
+We use four datasets provided in the original code, including Beauty, Movielens-1M, Video, and Steam. The hyperparameters used in the experiments are closely aligned with with those in the original paper. Specifically, we set the embedding size to 50, the learning rate to 0.001, the batch size to 128, the layer size to 2, the dropout rate to 0.2 for Movielens-1M and 0.5 for other datasets. The maximum sequence length is set to 200 for Movielens-1M and 50 for other datasets. We run maximum 500 epochs on Steam and 1000 epochs on other datasets.
+
+Note that in this experiment, the BCE loss is used, and the sampled-based evaluation for NDCG@10 and HR@10 is applied. The more advanced Softmax Loss (SL) has already been tested in [#47](https://github.com/pmixer/SASRec.pytorch/issues/47), where the overall (non-sampled) NDCG@10 and HR@10 are evaluated.
+
+## Results
+
+**Analysis.** Results below show that the original SASRec design generally performs worse than the Pre-LN and Post-LN designs. Additionally, the Pre-LN design shows larger improvements than the Post-LN design in three datasets.
+
+**NDCG@10 Results.**
+
+| Norm Type | Beauty | Movielens-1M | Video | Steam |
+| --- | :---: | :---: | :---: | :---: |
+| Original SASRec | 0.3104 | 0.5946 | 0.5308 | 0.6167 |
+| Pre-LN | **0.3193** | 0.5940 | **0.5376** | **0.6284** |
+| Post-LN | 0.3146 | **0.5995** | 0.5297 | 0.6201 |
+
+**HR@10 Results.**
+
+| Norm Type | Beauty | Movielens-1M | Video | Steam |
+| --- | :---: | :---: | :---: | :---: |
+| Original SASRec | 0.4669 | 0.8242 | 0.7318 | 0.8629 |
+| Pre-LN | **0.4784** | 0.8252 | **0.7442** | **0.8702** |
+| Post-LN | 0.4696 | **0.8270** | 0.7350 | 0.8684 |
+
+## Modifications
+
+Given the results above and [#47](https://github.com/pmixer/SASRec.pytorch/issues/47), we suggest to use standard LN in SASRec. We modified the original norm design (cf. [lines 79-83 in model.py](https://github.com/pmixer/SASRec.pytorch/blob/main/python/model.py#L79-L83)), providing a `norm_first` option to choose the Pre-LN (True) or Post-LN (False) design.

--- a/python/main.py
+++ b/python/main.py
@@ -26,6 +26,7 @@ parser.add_argument('--l2_emb', default=0.0, type=float)
 parser.add_argument('--device', default='cuda', type=str)
 parser.add_argument('--inference_only', default=False, type=str2bool)
 parser.add_argument('--state_dict_path', default=None, type=str)
+parser.add_argument('--norm_first', action='store_true', default=False)
 
 args = parser.parse_args()
 if not os.path.isdir(args.dataset + '_' + args.train_dir):

--- a/python/model.py
+++ b/python/model.py
@@ -16,7 +16,6 @@ class PointWiseFeedForward(torch.nn.Module):
     def forward(self, inputs):
         outputs = self.dropout2(self.conv2(self.relu(self.dropout1(self.conv1(inputs.transpose(-1, -2))))))
         outputs = outputs.transpose(-1, -2) # as Conv1D requires (N, C, Length)
-        outputs += inputs
         return outputs
 
 # pls use the following self-made multihead attention layer
@@ -76,15 +75,12 @@ class SASRec(torch.nn.Module):
 
         for i in range(len(self.attention_layers)):
             seqs = torch.transpose(seqs, 0, 1)
-            Q = self.attention_layernorms[i](seqs)
-            mha_outputs, _ = self.attention_layers[i](Q, seqs, seqs, 
+            mha_outputs, _ = self.attention_layers[i](seqs, seqs, seqs,
                                             attn_mask=attention_mask)
                                             # need_weights=False) this arg do not work?
-            seqs = Q + mha_outputs
+            seqs = self.attention_layernorms[i](seqs + mha_outputs)
             seqs = torch.transpose(seqs, 0, 1)
-
-            seqs = self.forward_layernorms[i](seqs)
-            seqs = self.forward_layers[i](seqs)
+            seqs = self.forward_layernorms[i](seqs + self.forward_layers[i](seqs))
 
         log_feats = self.last_layernorm(seqs) # (U, T, C) -> (U, -1, C)
 

--- a/python/model.py
+++ b/python/model.py
@@ -29,6 +29,7 @@ class SASRec(torch.nn.Module):
         self.user_num = user_num
         self.item_num = item_num
         self.dev = args.device
+        self.norm_first = args.norm_first
 
         # TODO: loss += args.l2_emb for regularizing embedding vectors during training
         # https://stackoverflow.com/questions/42704283/adding-l1-l2-regularization-in-pytorch
@@ -75,12 +76,19 @@ class SASRec(torch.nn.Module):
 
         for i in range(len(self.attention_layers)):
             seqs = torch.transpose(seqs, 0, 1)
-            mha_outputs, _ = self.attention_layers[i](seqs, seqs, seqs,
-                                            attn_mask=attention_mask)
-                                            # need_weights=False) this arg do not work?
-            seqs = self.attention_layernorms[i](seqs + mha_outputs)
-            seqs = torch.transpose(seqs, 0, 1)
-            seqs = self.forward_layernorms[i](seqs + self.forward_layers[i](seqs))
+            if self.norm_first:
+                x = self.attention_layernorms[i](seqs)
+                mha_outputs, _ = self.attention_layers[i](x, x, x,
+                                                attn_mask=attention_mask)
+                seqs = seqs + mha_outputs
+                seqs = torch.transpose(seqs, 0, 1)
+                seqs = seqs + self.forward_layers[i](self.forward_layernorms[i](seqs))
+            else:
+                mha_outputs, _ = self.attention_layers[i](seqs, seqs, seqs,
+                                                attn_mask=attention_mask)
+                seqs = self.attention_layernorms[i](seqs + mha_outputs)
+                seqs = torch.transpose(seqs, 0, 1)
+                seqs = self.forward_layernorms[i](seqs + self.forward_layers[i](seqs))
 
         log_feats = self.last_layernorm(seqs) # (U, T, C) -> (U, -1, C)
 


### PR DESCRIPTION
# Correct the LayerNorm in SASRec

As [#47](https://github.com/pmixer/SASRec.pytorch/issues/47) mentioned, we found that the LayerNorm in SASRec may be incorrectly implemented. Here we provide some [empirical results](https://github.com/Tiny-Snow/SASRec.pytorch/blob/main/Result_Norm.md) to verify that the standard (Pre- or Post-) norm may be better.

## Experimental Settings

We use four datasets provided in the original code, including Beauty, Movielens-1M, Video, and Steam. The hyperparameters used in the experiments are closely aligned with with those in the original paper. Specifically, we set the embedding size to 50, the learning rate to 0.001, the batch size to 128, the layer size to 2, the dropout rate to 0.2 for Movielens-1M and 0.5 for other datasets. The maximum sequence length is set to 200 for Movielens-1M and 50 for other datasets. We run maximum 500 epochs on Steam and 1000 epochs on other datasets.

Note that in this experiment, the BCE loss is used, and the sampled-based evaluation for NDCG@10 and HR@10 is applied. The more advanced Softmax Loss (SL) has already been tested in [#47](https://github.com/pmixer/SASRec.pytorch/issues/47), where the overall (non-sampled) NDCG@10 and HR@10 are evaluated.

## Results

**Analysis.** Results below show that the original SASRec design generally performs worse than the Pre-LN and Post-LN designs. Additionally, the Pre-LN design shows larger improvements than the Post-LN design in three datasets.

**NDCG@10 Results.**

| Norm Type | Beauty | Movielens-1M | Video | Steam |
| --- | :---: | :---: | :---: | :---: |
| Original SASRec | 0.3104 | 0.5946 | 0.5308 | 0.6167 |
| Pre-LN | **0.3193** | 0.5940 | **0.5376** | **0.6284** |
| Post-LN | 0.3146 | **0.5995** | 0.5297 | 0.6201 |

**HR@10 Results.**

| Norm Type | Beauty | Movielens-1M | Video | Steam |
| --- | :---: | :---: | :---: | :---: |
| Original SASRec | 0.4669 | 0.8242 | 0.7318 | 0.8629 |
| Pre-LN | **0.4784** | 0.8252 | **0.7442** | **0.8702** |
| Post-LN | 0.4696 | **0.8270** | 0.7350 | 0.8684 |

## Modifications

Given the results above and [#47](https://github.com/pmixer/SASRec.pytorch/issues/47), we suggest to use standard LN in SASRec. We modified the original norm design (cf. [lines 79-83 in model.py](https://github.com/pmixer/SASRec.pytorch/blob/main/python/model.py#L79-L83)), providing a `norm_first` option to choose the Pre-LN (True) or Post-LN (False) design.